### PR TITLE
Usm-34 Use gorilla mux as router

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -9,13 +9,14 @@ func makeFindUserEndpoint(svc UserManagerServiceInterface) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(findUserRequest)
 		u, err := svc.FindUser(req.Id)
-		if err != nil {
-			return findUserResponse{Err: err.Error()}, nil
-		}
+		//if err != nil {
+		//	return findUserResponse{Err: err}, err
+		//}
 		return findUserResponse{
 			Id: u.Id(),
 			Name: u.Name(),
 			Email: u.Email(),
+			Err: err,
 		}, nil
 	}
 }

--- a/endpoint.go
+++ b/endpoint.go
@@ -9,9 +9,6 @@ func makeFindUserEndpoint(svc UserManagerServiceInterface) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(findUserRequest)
 		u, err := svc.FindUser(req.Id)
-		//if err != nil {
-		//	return findUserResponse{Err: err}, err
-		//}
 		return findUserResponse{
 			Id: u.Id(),
 			Name: u.Name(),

--- a/main.go
+++ b/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
-
-	gokitlog "github.com/go-kit/kit/log"
 	"os/signal"
 	"syscall"
-	"fmt"
+
+	gokitlog "github.com/go-kit/kit/log"
 )
 
 
@@ -16,7 +16,7 @@ func main() {
 	svc = &UserManagerService{}
 
 	logger := gokitlog.NewLogfmtLogger(os.Stderr)
-	svc = loggingMiddleware{logger, svc}
+	svc = loggingMiddleware{logger,svc}
 
 	handler := MakeHTTPHandler(svc, logger)
 
@@ -29,8 +29,8 @@ func main() {
 	}()
 
 	go func() {
-		logger.Log("transport", "HTTP", "addr", ":8080")
-		errs <- http.ListenAndServe(":8080", handler)
+		logger.Log("transport", "HTTP", "addr", ":8088")
+		errs <- http.ListenAndServe(":8088", handler)
 	}()
 
 	logger.Log("exit", <-errs)

--- a/main.go
+++ b/main.go
@@ -22,25 +22,13 @@ func main() {
 	logger := gokitlog.NewLogfmtLogger(os.Stderr)
 	svc = loggingMiddleware{logger, svc}
 
-	findUserHandler := httptransport.NewServer(
+	findUsersHandler := httptransport.NewServer(
 		makeFindUserEndpoint(svc),
 		decodeFindUserRequest,
 		encodeResponse,
 	)
 
-	http.Handle("/user", findUserHandler)
-	log.Fatal(http.ListenAndServe(":8080", findUserHandler))
+	http.Handle("/user", findUsersHandler)
+	http.Handle("/user", findUsersHandler)
+	log.Fatal(http.ListenAndServe(":8080", findUsersHandler))
 }
-
-func decodeFindUserRequest(_ context.Context, r *http.Request) (interface{}, error) {
-	var request findUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		return nil, err
-	}
-	return request, nil
-}
-
-func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
-	return json.NewEncoder(w).Encode(response)
-}
-

--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"net/http"
 	"os"
-	//"os/signal"
-	//"syscall"
-	//"fmt"
 
 	gokitlog "github.com/go-kit/kit/log"
 	"os/signal"

--- a/main.go
+++ b/main.go
@@ -18,9 +18,6 @@ func main() {
 	var svc UserManagerServiceInterface
 	svc = &UserManagerService{}
 
-	//endpoint := makeFindUserEndpoint(svc)
-	//endpoint = loggingMiddleware(gokitlog.NewContext(logger).With("method", "users"))(endpoint)
-
 	logger := gokitlog.NewLogfmtLogger(os.Stderr)
 	svc = loggingMiddleware{logger, svc}
 
@@ -40,22 +37,4 @@ func main() {
 	}()
 
 	logger.Log("exit", <-errs)
-
-	//srv := &http.Server{
-	//	Handler:      handler,
-	//	Addr:         "127.0.0.1:8080",
-	//	WriteTimeout: 15 * time.Second,
-	//	ReadTimeout:  15 * time.Second,
-	//}
-	//log.Fatal(srv.ListenAndServe())
-
-	//findUsersHandler := httptransport.NewServer(
-	//	makeFindUserEndpoint(svc),
-	//	decodeFindUserRequest,
-	//	encodeResponse,
-	//)
-	//
-	//http.Handle("/user", findUsersHandler)
-	//http.Handle("/user", findUsersHandler)
-	//log.Fatal(http.ListenAndServe(":8080", findUsersHandler))
 }

--- a/request.go
+++ b/request.go
@@ -15,4 +15,4 @@ type findUserResponse struct {
 	Err error `json:"err,omitempty"` // errors don't JSON-marshal, so we use a string
 }
 
-func (r findUserResponse) error() error { return r.Err }
+func (f findUserResponse) error() error { return f.Err }

--- a/request.go
+++ b/request.go
@@ -12,5 +12,7 @@ type findUserResponse struct {
 	Name string `json:"name"`
 	Email string `json:"email"`
 	Password string `json:"password"`
-	Err string `json:"err,omitempty"` // errors don't JSON-marshal, so we use a string
+	Err error `json:"err,omitempty"` // errors don't JSON-marshal, so we use a string
 }
+
+func (r findUserResponse) error() error { return r.Err }

--- a/request.go
+++ b/request.go
@@ -12,7 +12,7 @@ type findUserResponse struct {
 	Name string `json:"name"`
 	Email string `json:"email"`
 	Password string `json:"password"`
-	Err error `json:"err,omitempty"` // errors don't JSON-marshal, so we use a string
+	Err error `json:"err,omitempty"`
 }
 
 func (f findUserResponse) error() error { return f.Err }

--- a/transport.go
+++ b/transport.go
@@ -31,7 +31,7 @@ func MakeHTTPHandler(s UserManagerServiceInterface, logger log.Logger) http.Hand
 	// GET     /user/:id			retrieves the given user by id
 	// GET     /user                       	retrieve all users given the search parameters
 
-	// try it with this: curl -X GET localhost:8080/user/2
+	// try it with this: curl -X GET localhost:8088/user/2
 	r.Methods("GET").Path("/user/{id}").Handler(httptransport.NewServer(
 		makeFindUserEndpoint(s),
 		decodeFindUserRequest,

--- a/transport.go
+++ b/transport.go
@@ -39,23 +39,10 @@ func MakeHTTPHandler(s UserManagerServiceInterface, logger log.Logger) http.Hand
 		options...,
 	))
 
-	//r.Methods("GET").Path("/user/{id}").Handler(httptransport.NewServer(
-	//	e.GetProfileEndpoint,
-	//	decodeGetProfileRequest,
-	//	encodeResponse,
-	//	options...,
-	//))
-
 	return r
 }
 
 func decodeFindUserRequest(_ context.Context, r *http.Request) (interface{}, error) {
-	var request findUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		return nil, err
-	}
-	return request, nil
-
 	vars := mux.Vars(r)
 	id, ok := vars["id"]
 	if !ok {

--- a/transport.go
+++ b/transport.go
@@ -44,6 +44,8 @@ func MakeHTTPHandler(s UserManagerServiceInterface, logger log.Logger) http.Hand
 	//	encodeResponse,
 	//	options...,
 	//))
+
+	return r
 }
 
 func decodeFindUserRequest(_ context.Context, r *http.Request) (interface{}, error) {

--- a/transport.go
+++ b/transport.go
@@ -1,3 +1,122 @@
 package main
 
+import (
+	"errors"
+	"net/http"
 
+	"github.com/gorilla/mux"
+
+	"github.com/go-kit/kit/log"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"encoding/json"
+	"context"
+	"bytes"
+	"io/ioutil"
+)
+
+var (
+	// ErrBadRouting is returned when an expected path variable is missing.
+	// It always indicates programmer error.
+	ErrBadRouting = errors.New("inconsistent mapping between route and handler (programmer error)")
+)
+
+func MakeHTTPHandler(s UserManagerServiceInterface, logger log.Logger) http.Handler {
+	r := mux.NewRouter()
+	//e := MakeServerEndpoints(s)
+	options := []httptransport.ServerOption{
+		httptransport.ServerErrorLogger(logger),
+		httptransport.ServerErrorEncoder(encodeError),
+	}
+
+	// GET     /user/:id			retrieves the given user by id
+	// GET     /user                       	retrieve all users given the search parameters
+
+	r.Methods("GET").Path("/user/{id}").Handler(httptransport.NewServer(
+		makeFindUserEndpoint(s),
+		decodeFindUserRequest,
+		encodeResponse,
+		options...,
+	))
+
+	//r.Methods("GET").Path("/user/{id}").Handler(httptransport.NewServer(
+	//	e.GetProfileEndpoint,
+	//	decodeGetProfileRequest,
+	//	encodeResponse,
+	//	options...,
+	//))
+}
+
+func decodeFindUserRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	var request findUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return nil, err
+	}
+	return request, nil
+
+	vars := mux.Vars(r)
+	id, ok := vars["id"]
+	if !ok {
+		return nil, ErrBadRouting
+	}
+	return findUserRequest{Id: id}, nil
+}
+
+
+// errorer is implemented by all concrete response types that may contain
+// errors. It allows us to change the HTTP response code without needing to
+// trigger an endpoint (transport-level) error. For more information, read the
+// big comment in endpoints.go.
+type errorer interface {
+	error() error
+}
+
+// encodeResponse is the common method to encode all response types to the
+// client. I chose to do it this way because, since we're using JSON, there's no
+// reason to provide anything more specific. It's certainly possible to
+// specialize on a per-response (per-method) basis.
+func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	if e, ok := response.(errorer); ok && e.error() != nil {
+		// Not a Go kit transport error, but a business-logic error.
+		// Provide those as HTTP errors.
+		encodeError(ctx, e.error(), w)
+		return nil
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	return json.NewEncoder(w).Encode(response)
+}
+
+// encodeRequest likewise JSON-encodes the request to the HTTP request body.
+// Don't use it directly as a transport/http.Client EncodeRequestFunc:
+// profilesvc endpoints require mutating the HTTP method and request path.
+func encodeRequest(_ context.Context, req *http.Request, request interface{}) error {
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(request)
+	if err != nil {
+		return err
+	}
+	req.Body = ioutil.NopCloser(&buf)
+	return nil
+}
+
+
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
+	if err == nil {
+		panic("encodeError with nil error")
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(codeFrom(err))
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": err.Error(),
+	})
+}
+
+func codeFrom(err error) int {
+	switch err {
+	//case ErrNotFound:
+	//	return http.StatusNotFound
+	//case ErrAlreadyExists, ErrInconsistentIDs:
+	//	return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -31,6 +31,7 @@ func MakeHTTPHandler(s UserManagerServiceInterface, logger log.Logger) http.Hand
 	// GET     /user/:id			retrieves the given user by id
 	// GET     /user                       	retrieve all users given the search parameters
 
+	// try it with this: curl -X GET localhost:8080/user/2
 	r.Methods("GET").Path("/user/{id}").Handler(httptransport.NewServer(
 		makeFindUserEndpoint(s),
 		decodeFindUserRequest,


### PR DESCRIPTION
Title: **Use gorilla mux as router**

Motivation: 
The standard router in Go won't allow us to do things like `GET /user/{id}`. It only supports static URLs.

Resolution:
We've replaced the standard router with the [gorilla mux router](http://www.gorillatoolkit.org/pkg/mux), which is much more powerful and supports dynamic routing.

Ticket: #34 
